### PR TITLE
minor: Update svelte-hydrated to version 2.0.0 and adjust import for hydration check

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "typescript": "5.7.2",
     "vite": "6.0.6",
     "@sveltejs/vite-plugin-svelte": "5.0.3",
-    "svelte-hydrated": "1.0.31"
+    "svelte-hydrated": "2.0.0"
   },
   "dependencies": {
     "@jill64/universal-sanitizer": "1.3.6"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jill64/svelte-sanitize",
   "description": "💎 Safe html expansion for Svelte with universal-sanitize",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "main": "dist/index.js",
   "type": "module",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/jill64/svelte-sanitize.git",
-    "image": "https://opengraph.githubassets.com/947c81f2279114cb7972e02a60ab51d65876995d8db6c838a55e34889729bac6/jill64/svelte-sanitize"
+    "image": "https://opengraph.githubassets.com/b1a11a4b7b52450073e0221e7bc4c1dce5712839dfdd3e87314058edf8986417/jill64/svelte-sanitize"
   },
   "keywords": [
     "html",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,8 +43,8 @@ importers:
         specifier: 5.16.0
         version: 5.16.0
       svelte-hydrated:
-        specifier: 1.0.31
-        version: 1.0.31(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)
+        specifier: 2.0.0
+        version: 2.0.0(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)
       typescript:
         specifier: 5.7.2
         version: 5.7.2
@@ -1549,6 +1549,12 @@ packages:
     peerDependencies:
       '@sveltejs/kit': ^2.0.0
       svelte: ^4.0.0
+
+  svelte-hydrated@2.0.0:
+    resolution: {integrity: sha512-/X+wtfsAERtzv8KEqNwe77UcO3qaMjiEh9FG5tps/cU6Q4EVujQqAJpOH8UlN5snSp5BEeKC5lv+RDL1TOJ/bQ==}
+    peerDependencies:
+      '@sveltejs/kit': ^2.0.0
+      svelte: ^5.0.0
 
   svelte-mq-store@3.0.0:
     resolution: {integrity: sha512-1gwR2QdO9VZZfDdCwOV2BOGAWmkK7388dUsC61CUomN8L3hEmh2VDiS9UaoSGhHeLNATJbOPhYi0q2SkjVlP/w==}
@@ -3142,6 +3148,11 @@ snapshots:
       highlight.js: 11.11.1
 
   svelte-hydrated@1.0.31(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0):
+    dependencies:
+      '@sveltejs/kit': 2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2))
+      svelte: 5.16.0
+
+  svelte-hydrated@2.0.0(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0):
     dependencies:
       '@sveltejs/kit': 2.15.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2)))(svelte@5.16.0)(vite@6.0.6(@types/node@22.10.2))
       svelte: 5.16.0

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
   import { Render } from '$lib'
   import { HighlightSvelte } from '@jill64/npm-demo-layout/highlight'
-  import { hydrated } from 'svelte-hydrated'
+  import { is } from 'svelte-hydrated'
   import { code } from './code'
   import { markup } from './markup'
 </script>
 
 <main>
   <div>
-    <Render html={markup($hydrated)} />
+    <Render html={markup(is.hydrated)} />
   </div>
   <div style:font-size="large" style:overflow-x="auto">
     <HighlightSvelte {code} />


### PR DESCRIPTION
Upgrade svelte-hydrated to the latest version and modify the import statement to use 'is' for the hydration check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated package version to 2.1.0

- **Chores**
	- Updated repository image URL
	- Updated `svelte-hydrated` library to version 2.0.0
	- Modified hydration state import and usage in component

<!-- end of auto-generated comment: release notes by coderabbit.ai -->